### PR TITLE
fix cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ configure_file(
 
 install(
 	FILES
-		${CMAKE_BINARY_DIR}/uchardet.pc
+		${CMAKE_CURRENT_BINARY_DIR}/uchardet.pc
 	DESTINATION
 		${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )


### PR DESCRIPTION
the output of `configure_file` is actually placed under `CMAKE_CURRENT_BINARY_DIR` and not `CMAKE_BINARY_DIR`. see https://cmake.org/cmake/help/latest/command/configure_file.html